### PR TITLE
fixes approve for run stage

### DIFF
--- a/vars/osio.groovy
+++ b/vars/osio.groovy
@@ -154,7 +154,9 @@ def main(params) {
   if (stages.contains("stage")) {
     stage('Deploy to staging') {
       deployEnvironment("stage", "${currentUser}", "${templateISDest}", "${templateDC}", "${templateRoute}")
-      askForInput()
+      if(stages.contains("run")) {
+        askForInput()
+      }
     }
   }
 


### PR DESCRIPTION
Right now pipeline asks user input for deploying the application to run through from stage phase.
It asks for user input for approving even though pipeline says it has only stage phase not run. 
This fixes user input flow if Jenkins file has run env otherwise it doesn't ask for user input.

![image](https://user-images.githubusercontent.com/28615674/42939006-e17da33e-8b71-11e8-9769-6b9cbe2d3b1c.png)

Fixes #16