### PR TITLE
Fixes the spawn for OC workload

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,5 +253,4 @@ Parameters
 |  checkout_scm  |    false   |      true      |    whether you want git code or not for performing commands    |
 |    commands    |    false   |      null      |             commands that you want to execute                  |
 
-Note: For the `oc` image its doesn't spin up new pod, instead it execute the commands on 
-the master node.
+NOTE: For oc image, as an optimisation, a new pod is not started instead commands and body are executed on master itself

--- a/README.md
+++ b/README.md
@@ -253,4 +253,5 @@ Parameters
 |  checkout_scm  |    false   |      true      |    whether you want git code or not for performing commands    |
 |    commands    |    false   |      null      |             commands that you want to execute                  |
 
-
+Note: For the `oc` image its doesn't spin up new pod, instead it execute the commands on 
+the master node.

--- a/vars/deploy.groovy
+++ b/vars/deploy.groovy
@@ -32,8 +32,9 @@ def call(Map args = [:]) {
     }
   }
 
+  def image = config.runtime() ?: 'oc'
   stage("Deploy to ${args.env}") {
-    spawn(image: "oc") {
+    spawn(image: image) {
       def userNS = Utils.usersNamespace();
       def deployNS = userNS + "-" + args.env;
 

--- a/vars/spawn.groovy
+++ b/vars/spawn.groovy
@@ -7,19 +7,28 @@ def call(Map args = [:], body = null){
 
     def spec = specForImage(args.image, args.version?: 'latest')
     def checkoutScm = args.checkout_scm ?: true
-    pod(name: args.image, image: spec.image, shell: spec.shell) {
-      if (checkoutScm) {
-        checkout scm
-      }
 
-      if (args.commands != null) {
-          sh args.commands
-      }
+    if (args.image == "oc") {
+      executeCode(args, body)
+    } else {
+      pod(name: args.image, image: spec.image, shell: spec.shell) {
+        if (checkoutScm) {
+          checkout scm
+        }
 
-      if (body != null) {
-          body()
+        executeCode(args, body)
       }
     }
+}
+
+def executeCode(args, body) {
+  if (args.commands != null) {
+    sh args.commands
+  }
+
+  if (body != null) {
+    body()
+  }
 }
 
 def specForImage(image, version){

--- a/vars/spawn.groovy
+++ b/vars/spawn.groovy
@@ -8,25 +8,27 @@ def call(Map args = [:], body = null){
     def spec = specForImage(args.image, args.version?: 'latest')
     def checkoutScm = args.checkout_scm ?: true
 
+    // oc is available on master so don't spawn unnecessarily
     if (args.image == "oc") {
-      executeCode(args, body)
-    } else {
-      pod(name: args.image, image: spec.image, shell: spec.shell) {
-        if (checkoutScm) {
-          checkout scm
-        }
+      execute(args.commands, body)
+      return
+    }
 
-        executeCode(args, body)
+    pod(name: args.image, image: spec.image, shell: spec.shell) {
+      if (checkoutScm) {
+        checkout scm
       }
+
+      execute(args.commands, body)
     }
 }
 
-def executeCode(args, body) {
-  if (args.commands != null) {
-    sh args.commands
+def execute(commands, body) {
+  if (commands) {
+    sh commands
   }
 
-  if (body != null) {
+  if (body) {
     body()
   }
 }


### PR DESCRIPTION
Master node is already equipped with OC CLI, heance
it can execute the OC workload. This patch executes OC commands
on master node instead of spinning the new node. Updates the doc
as well.