### PR TITLE
build/deploy: use oc image by default

### DIFF
--- a/vars/build.groovy
+++ b/vars/build.groovy
@@ -19,7 +19,11 @@ def call(Map args) {
       }
 
       def namespace = args.namespace ?: Utils.usersNamespace()
-      def image = config.runtime() ?: 'oc'
+
+      def image = args.image
+      if (!image) {
+        image = args.commands ? config.runtime() : 'oc'
+      }
 
       def status = ""
       spawn(image: image, version: config.version(), commands: args.commands) {

--- a/vars/build.groovy
+++ b/vars/build.groovy
@@ -2,47 +2,47 @@ import io.openshift.Events
 import io.openshift.Utils
 
 def call(Map args) {
-    stage("Build application") {
-      if (!args.resources) {
-        error "Missing manadatory parameter: resources"
+  stage("Build application") {
+    if (!args.resources) {
+      error "Missing manadatory parameter: resources"
+    }
+
+
+    // can pass single or multiple maps
+    def res = Utils.mergeResources(args.resources)
+
+    def required = ['ImageStream', 'BuildConfig']
+    def found = res.keySet()
+    def missing = required - found
+    if (missing) {
+      error "Missing mandatory build resources params: $missing; found: $found"
+    }
+
+    def namespace = args.namespace ?: Utils.usersNamespace()
+
+    def image = args.image
+    if (!image) {
+      image = args.commands ? config.runtime() : 'oc'
+    }
+
+    def status = ""
+    spawn(image: image, version: config.version(), commands: args.commands) {
+      Events.emit("build.start")
+      try {
+        createImageStream(res.ImageStream, namespace)
+        buildProject(res.BuildConfig, namespace)
+        status = "pass"
+      } catch (e) {
+        status = "fail"
+      } finally {
+        Events.emit(["build.end", "build.${status}"], [status: status, namespace: namespace])
       }
 
-
-      // can pass single or multiple maps
-      def res = Utils.mergeResources(args.resources)
-
-      def required = ['ImageStream', 'BuildConfig']
-      def found = res.keySet()
-      def missing = required - found
-      if (missing) {
-        error "Missing mandatory build resources params: $missing; found: $found"
-      }
-
-      def namespace = args.namespace ?: Utils.usersNamespace()
-
-      def image = args.image
-      if (!image) {
-        image = args.commands ? config.runtime() : 'oc'
-      }
-
-      def status = ""
-      spawn(image: image, version: config.version(), commands: args.commands) {
-        Events.emit("build.start")
-        try {
-          createImageStream(res.ImageStream, namespace)
-          buildProject(res.BuildConfig, namespace)
-          status = "pass"
-        } catch (e) {
-          status = "fail"
-        } finally {
-          Events.emit(["build.end", "build.${status}"], [status: status, namespace: namespace])
-        }
-
-        if (status == 'fail') {
-          error "Build failed"
-        }
+      if (status == 'fail') {
+        error "Build failed"
       }
     }
+  }
 }
 
 def createImageStream(imageStreams, namespace) {

--- a/vars/deploy.groovy
+++ b/vars/deploy.groovy
@@ -32,7 +32,11 @@ def call(Map args = [:]) {
     }
   }
 
-  def image = config.runtime() ?: 'oc'
+  def image = args.image
+  if (!image) {
+    image = args.commands ? config.runtime() : 'oc'
+  }
+
   stage("Deploy to ${args.env}") {
     spawn(image: image) {
       def userNS = Utils.usersNamespace();


### PR DESCRIPTION
Both `build` and `deploy` command will start using `oc` image (doesn't
result in creating a slave pod) by default unless, `commands` argument
or `image` is set.