### PR TITLE
deploy: annotate routes only if present

### DIFF
--- a/vars/deploy.groovy
+++ b/vars/deploy.groovy
@@ -9,7 +9,7 @@ def call(Map args = [:]) {
     error "Missing manadatory parameter: resources"
   }
 
-  def required = ['ImageStream', 'DeploymentConfig', 'Service', 'Route', 'meta']
+  def required = ['ImageStream', 'DeploymentConfig', 'meta']
   // can pass single or multiple maps
   def res = Utils.mergeResources(args.resources)
   def found = res.keySet()

--- a/vars/deploy.groovy
+++ b/vars/deploy.groovy
@@ -92,6 +92,10 @@ def verifyDeployments(ns, dcs) {
 }
 
 def annotateRoutes(ns, env, routes, version) {
+  if (!routes) {
+    return
+  }
+
   def svcURLs = routes.inject(''){ acc, r -> acc + "\n  ${r.metadata.name}: ${displayRouteURL(ns, r)}" }
   def depVersions = routes.inject(''){ acc, r ->  acc + "\n  ${r.metadata.name}: $version" }
 

--- a/vars/deploy.groovy
+++ b/vars/deploy.groovy
@@ -10,14 +10,7 @@ def call(Map args = [:]) {
   }
 
   def required = ['ImageStream', 'DeploymentConfig', 'meta']
-  // can pass single or multiple maps
-  println "------------------------------------------------------"
-  println args.resources
-
   def res = Utils.mergeResources(args.resources)
-  println "---after merging ---------------------------------------------------"
-  println res
-  println "------------------------------------------------------"
 
   def found = res.keySet()
   def missing = required - found

--- a/vars/deploy.groovy
+++ b/vars/deploy.groovy
@@ -11,7 +11,13 @@ def call(Map args = [:]) {
 
   def required = ['ImageStream', 'DeploymentConfig', 'meta']
   // can pass single or multiple maps
+  println resources
+
   def res = Utils.mergeResources(args.resources)
+  println "------------------------------------------------------"
+  println res
+  println "------------------------------------------------------"
+
   def found = res.keySet()
   def missing = required - found
   if (missing) {

--- a/vars/deploy.groovy
+++ b/vars/deploy.groovy
@@ -11,10 +11,11 @@ def call(Map args = [:]) {
 
   def required = ['ImageStream', 'DeploymentConfig', 'meta']
   // can pass single or multiple maps
-  println resources
+  println "------------------------------------------------------"
+  println args.resources
 
   def res = Utils.mergeResources(args.resources)
-  println "------------------------------------------------------"
+  println "---after merging ---------------------------------------------------"
   println res
   println "------------------------------------------------------"
 


### PR DESCRIPTION
`deploy` command tries to add a route annotation even if there isn't
any `route`. This cause deploy for fail in cases of multi-containers
where a deployment may not have any route associated.

This patch fixes the issue by adding the annotation only if route
is present.