### PR TITLE
fixes #43 to update build event arguments and add kind check

### DIFF
--- a/src/io/openshift/Utils.groovy
+++ b/src/io/openshift/Utils.groovy
@@ -17,6 +17,7 @@ class Utils {
   static def ocApply(script, resource, namespace) {
     def buildNum = script.env.BUILD_NUMBER
     def resources = [resource].flatten()
+
     resources.each { r ->
       def kind = r.kind.toLowerCase()
       def resourceFile = ".openshiftio/.tmp-${namespace}-${buildNum}-${kind}.yaml"

--- a/vars/build.groovy
+++ b/vars/build.groovy
@@ -36,7 +36,7 @@ def call(Map args) {
         status = "fail"
       } finally {
         Events.emit(["build.end", "build.${status}"],
-                    [status: status, namespace: namespace, gitURL: gitURL, commitHash: commitHash])
+                    [status: status, namespace: namespace, git: [url: gitURL, commit: commitHash]])
       }
 
       if (status == 'fail') {

--- a/vars/build.groovy
+++ b/vars/build.groovy
@@ -29,12 +29,10 @@ def call(Map args) {
     spawn(image: image, version: config.version(), commands: args.commands) {
       Events.emit("build.start")
       try {
-        echo "${res}"
         createImageStream(res.ImageStream, namespace)
         buildProject(res.BuildConfig, namespace)
         status = "pass"
       } catch (e) {
-        echo "error : ${e}"
         status = "fail"
       } finally {
         Events.emit(["build.end", "build.${status}"],

--- a/vars/build.groovy
+++ b/vars/build.groovy
@@ -19,23 +19,26 @@ def call(Map args) {
     }
 
     def namespace = args.namespace ?: Utils.usersNamespace()
-
     def image = args.image
     if (!image) {
       image = args.commands ? config.runtime() : 'oc'
     }
-
+    def gitURL = Utils.shWithOutput(this, "git config remote.origin.url")
+    def commitHash = Utils.shWithOutput(this, "git rev-parse --short HEAD")
     def status = ""
     spawn(image: image, version: config.version(), commands: args.commands) {
       Events.emit("build.start")
       try {
+        echo "${res}"
         createImageStream(res.ImageStream, namespace)
         buildProject(res.BuildConfig, namespace)
         status = "pass"
       } catch (e) {
+        echo "error : ${e}"
         status = "fail"
       } finally {
-        Events.emit(["build.end", "build.${status}"], [status: status, namespace: namespace])
+        Events.emit(["build.end", "build.${status}"],
+                    [status: status, namespace: namespace, gitURL: gitURL, commitHash: commitHash])
       }
 
       if (status == 'fail') {

--- a/vars/deploy.groovy
+++ b/vars/deploy.groovy
@@ -20,7 +20,7 @@ def call(Map args = [:]) {
 
   def tag = res.meta.tag
   if (!tag) {
-    error "Missing manadatory metadata: tag"
+    error "Missing mandatory metadata: tag"
   }
 
 
@@ -81,7 +81,6 @@ def applyResources(ns, res) {
   def allowed = { e -> !(e.key in ["ImageStream", "BuildConfig", "meta"]) }
   def resources = res.findAll(allowed)
     .collect({ it.value })
-
   Utils.ocApply(this, resources, ns)
 }
 


### PR DESCRIPTION
The  event listeners may need some information about the build,
like source git url, commit id etc.

This PR adds following arguments to the event
- gitURL - source git origin url
- commitHash  - commit id from which application is build

This patch also handles the case for `ocApply` resources if kind filed is empty.

Fixes #43