### PR TITLE
#4319 Adding java image in spawn.groovy, so that it can be used when java pod is required.

### DIFF
--- a/vars/spawn.groovy
+++ b/vars/spawn.groovy
@@ -60,6 +60,16 @@ def specForImage(image, version){
             shell: '/bin/bash'
       ],
     ],
+    "java": [
+      "latest": [
+            image: "openshift/jenkins-slave-maven-centos7:v4.0",
+            shell: '/bin/bash'
+      ],
+      "1.8": [
+            image: "openshift/jenkins-slave-maven-centos7:v4.0",
+            shell: '/bin/bash'
+      ],
+    ],
   ]
 
   // TODO: validate image in specs


### PR DESCRIPTION
The image used in the PR is the one which we are using for current java builds on osio added by @arilivigni 