### PR TITLE
Events: spread args when calling handlers

### DIFF
--- a/src/io/openshift/Events.groovy
+++ b/src/io/openshift/Events.groovy
@@ -25,7 +25,7 @@ class Events implements Serializable {
             if (!listeners[e]) {
                 return
             }
-            listeners[e].each { c -> c.call([name: e], args) }
+            listeners[e].each { c -> c.call([name: e], *args) }
         }
     }
 


### PR DESCRIPTION
When invoking event handlers, the old implementation passes all args
as an array instead of individual arguments. This causes

```
Events.emit(
  ["build.end", "build.${status}"],
  [status: status,
   namespace: namespace,
   git: [url: gitURL, commit: commitHash]]
)

```
to be received by a handler `Events.on("build.pass") {e , a -> ...}`
where a is a single element list like below which contain the map

```
[
  [status: status,
   namespace: namespace,
   git: [url: gitURL, commit: commitHash]]
]
```

And accessing `git.url` requires `a[0].git.url` which is unintuitive and
lacks symmetry.

This patch fixes it by using the spread operator (`*`) to spread the `args`
list when calling handler. So that git-url (e.g) can be accessed by
`a.git.url`