### PR TITLE
Validate resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ Parameters
 |      Name      |  Required  |         Default Value        |                             Description                                |
 |----------------|------------|------------------------------|------------------------------------------------------------------------|
 |      file      |   true     |  none           |    An relative path of resource yaml file.            |
-
+|      validate  |   false    |  true           |    A validation for resource yaml file.               |                       
 ### build
 
 This is the api which is responsible for doing s2i build, generating image and creating imagestream (if not exist)

--- a/vars/loadResources.groovy
+++ b/vars/loadResources.groovy
@@ -1,9 +1,14 @@
+import io.openshift.Utils
+
 def call(Map args = [:]) {
-  if(!args.file) {
+  if (!args.file) {
     error "Missing manadatory parameter: file"
   }
 
-  def yaml = readYaml(file: args.file)
+  def validate = args.validate == false ? false : true
+  if (validate) {
+    Utils.shWithOutput(this, "oc apply --dry-run=true --validate=true -f $args.file");
+  }
 
   // resources can be:
   //  - a single resource
@@ -12,7 +17,7 @@ def call(Map args = [:]) {
   //    and items property is a list of resources
   //
   // for each of the above, loadResources must return [kind: [Resources, ...]]
-
+  def yaml = readYaml(file: args.file)
   def isListKind = yaml instanceof Map && yaml.kind == "List"
   def resources = isListKind ? yaml.items : [yaml].flatten()
   return resources.groupBy({ r -> r.kind })


### PR DESCRIPTION
Jenkins throws null pointer exception if any field is mising in resource file.

This patch validates the resource file before processing it.

- Give option to validate template by default validates.
- For an invalid template show proper message and stop jenkins processing.
- Readme Update for loadResource method arguments.

Resolves : https://github.com/fabric8io/osio-pipeline/issues/52