### PR TITLE
fixes usersNamespace in Utils.groovy

### DIFF
--- a/src/io/openshift/Utils.groovy
+++ b/src/io/openshift/Utils.groovy
@@ -29,7 +29,7 @@ class Utils {
     }
   }
 
-  static String usersNamespace(oc) {
+  static String usersNamespace(oc = null) {
     def ns = currentNamespace(oc)
     if (ns.endsWith("-jenkins")) {
       return ns.substring(0, ns.lastIndexOf("-jenkins"))
@@ -37,7 +37,7 @@ class Utils {
     return ns
   }
 
-  static String currentNamespace(oc) {
+  static String currentNamespace(oc = null) {
     oc = oc ?: new DefaultOpenShiftClient()
     return oc.getNamespace()
   }


### PR DESCRIPTION
Changes in [testcases](https://github.com/fabric8io/osio-pipeline/pull/55) commit introduced
a bug in `Utils.usersNamespace` API which in turn
failing `build` API.

This patch fixes the regression happen
in https://github.com/fabric8io/osio-pipeline/pull/55