### PR TITLE
Refactors deploy and build API to use OC CLI

### DIFF
--- a/test/groovy/builds/BuildTest.groovy
+++ b/test/groovy/builds/BuildTest.groovy
@@ -54,7 +54,7 @@ class BuildTest extends PipelineHelper {
 
     // THEN
     assertStepExecutes("sh", "2-buildconfig")
-    assertStepExecutes("openshiftBuild", "buildConfig=nodejs-configmap-s2i-master")
+    assertStepExecutes("sh", "nodejs-configmap-s2i-master")
     assertJobStatusSuccess()
   }
 
@@ -69,8 +69,8 @@ class BuildTest extends PipelineHelper {
   }
 
   def mockOpenShiftBuild() {
-    helper.registerAllowedMethod("openshiftBuild", [Map], { p ->
-      return ""
+    helper.registerAllowedMethod("retry", [Integer, Closure], { i, c ->
+      c.call()
     })
   }
 

--- a/vars/build.groovy
+++ b/vars/build.groovy
@@ -1,5 +1,9 @@
 import io.openshift.Events
-import io.openshift.Utils
+
+import static io.openshift.Utils.mergeResources
+import static io.openshift.Utils.usersNamespace
+import static io.openshift.Utils.ocApply
+import static io.openshift.Utils.shWithOutput
 
 def call(Map args) {
   stage("Build Image") {
@@ -10,7 +14,7 @@ def call(Map args) {
     }
 
     // can pass single or multiple maps
-    def res = Utils.mergeResources(args.resources)
+    def res = mergeResources(args.resources)
 
     def required = ['ImageStream', 'BuildConfig']
     def found = res.keySet()
@@ -21,19 +25,19 @@ def call(Map args) {
       return
     }
 
-    def namespace = args.namespace ?: Utils.usersNamespace(args.osClient)
+    def namespace = args.namespace ?: usersNamespace(args.osClient)
     def image = args.image
     if (!image) {
       image = args.commands ? config.runtime() : 'oc'
     }
-    def gitURL = Utils.shWithOutput(this, "git config remote.origin.url")
-    def commitHash = Utils.shWithOutput(this, "git rev-parse --short HEAD")
+    def gitURL = shWithOutput(this, "git config remote.origin.url")
+    def commitHash = shWithOutput(this, "git rev-parse --short HEAD")
     def status = ""
     spawn(image: image, version: config.version(), commands: args.commands) {
       Events.emit("build.start")
       try {
-        createImageStream(res.ImageStream, namespace)
-        buildProject(res.BuildConfig, namespace)
+        createImageStream namespace, res.ImageStream
+        buildProject namespace, res.BuildConfig
         status = "pass"
       } catch (e) {
         status = "fail"
@@ -49,21 +53,15 @@ def call(Map args) {
   }
 }
 
-def createImageStream(imageStreams, namespace) {
-    imageStreams.each { imageStream ->
-        def isName = imageStream.metadata.name
-        def isFound = Utils.shWithOutput(this, "oc get is/$isName -n $namespace --ignore-not-found")
-        if (!isFound) {
-          Utils.ocApply(this, imageStream, namespace)
-        } else {
-          echo "image stream exist ${isName}"
-        }
+def createImageStream(ns, imageStreams) {
+    imageStreams.each { is ->
+      ocApply this, is, ns
     }
 }
 
-def buildProject(buildConfigs, namespace) {
-    buildConfigs.each { buildConfig ->
-        Utils.ocApply(this, buildConfig, namespace)
-        openshiftBuild(buildConfig: "${buildConfig.metadata.name}", showBuildLogs: 'true')
+def buildProject(ns, buildConfigs) {
+    buildConfigs.each { bc ->
+      ocApply this, bc, ns
+      sh "oc start-build ${bc.metadata.name} -n $ns -F"
     }
 }


### PR DESCRIPTION
At present build and deploy uses openshift jenkins
plugin to start build and verify the deployments.
This plugin has become deprecated now.
This patch replaces the plugin steps with OC CLI.

Triggers on DC varies from each DC's hence current
pipeline triggers more than deployments. Irrespective
of how triggers are defined, deploy
API should roll out a single deployment not multiple.
This patch also fixes triggers handling for
deployments. Makes sure it triggers a single
Deployment even though multiple configurations
have changed.

This patch also refactors following issues
- fixes method calling a convention for build and deploy API
- uses static import for Utils methods for better
  readability in build and deploy API
- enhances dc rollout pause/resume as
  per PR review comment

Fixes
 #95