### PR TITLE
Feature to register analytics plugin only if available

### DIFF
--- a/src/io/openshift/Plugins.groovy
+++ b/src/io/openshift/Plugins.groovy
@@ -2,12 +2,13 @@ package io.openshift
 
 import io.openshift.plugins.analytics
 import io.openshift.Globals
+import static io.openshift.Utils.pluginAvailable
 
 class Plugins implements Serializable {
     static def register() {
       // analytics plugins is enabled by default
       Globals.plugins["analytics"] = Globals.plugins["analytics"] ?: [disabled: false]
-      if (Globals.plugins["analytics"].disabled ?: false) {
+      if (Globals.plugins["analytics"].disabled ?: false || !pluginAvailable("bayesian")) {
         return
       }
       new analytics().register()

--- a/src/io/openshift/Plugins.groovy
+++ b/src/io/openshift/Plugins.groovy
@@ -8,7 +8,9 @@ class Plugins implements Serializable {
     static def register() {
       // analytics plugins is enabled by default
       Globals.plugins["analytics"] = Globals.plugins["analytics"] ?: [disabled: false]
-      if (Globals.plugins["analytics"].disabled ?: false || !pluginAvailable("bayesian")) {
+
+      def disabled = Globals.plugins["analytics"].disabled ?: false
+      if (disabled || !pluginAvailable("bayesian"))  {
         return
       }
       new analytics().register()

--- a/src/io/openshift/Utils.groovy
+++ b/src/io/openshift/Utils.groovy
@@ -122,4 +122,9 @@ class Utils {
     }
   }
 
+  // return true if given pluginName is available in Jenkins otherwise false
+  static boolean pluginAvailable(pluginName) {
+    return jenkins.model.Jenkins.instance.getPluginManager().getPlugin(pluginName) ? true : false
+  }
+
 }


### PR DESCRIPTION
This patch will add a feature to register
Analytics Plugin only if it is there in jenkins

Fixes #74