### PR TITLE
fixes osio coupling issue

### DIFF
--- a/vars/build.groovy
+++ b/vars/build.groovy
@@ -25,7 +25,7 @@ def call(Map args) {
       return
     }
 
-    def namespace = args.namespace ?: usersNamespace(args.osClient)
+    def namespace = args.env ?: usersNamespace(args.osClient)
     def image = args.image
     if (!image) {
       image = args.commands ? config.runtime() : 'oc'

--- a/vars/build.groovy
+++ b/vars/build.groovy
@@ -25,6 +25,7 @@ def call(Map args) {
       return
     }
 
+    echo "env :" + args.env instanceof 
     def namespace = args.env ?: usersNamespace(args.osClient)
     def image = args.image
     if (!image) {

--- a/vars/environment.groovy
+++ b/vars/environment.groovy
@@ -1,0 +1,22 @@
+import static io.openshift.Utils.usersNamespace
+
+def call(Map args = [:]){
+    if (!args.type) {
+        error "Missing manadatory parameter: type"
+        return
+    }
+
+    def userNS = usersNamespace(args.osClient)
+
+    if (args.type.equalsIgnoreCase("build")) { 
+        return userNS
+    }
+
+    if (args.type.equalsIgnoreCase("stage")) { 
+        return userNS + "-stage"
+    }
+
+    if (args.type.equalsIgnoreCase("run")) {
+        return userNS + "-run"
+    }
+}


### PR DESCRIPTION
Pipeline library is tightly coupled with OSIO
envionment considerations. At this moment
`build` and `deploy` API make some assumtion
about namespaces according to OSIO envionment.

This patch fixes `build` and `deploy` API env parameter,
which accepts complete namespaces rather partial names.
It's introduces new helper `envionment` to resolve
correct namespaces while working for OSIO pipeline.

Fixes
 - https://github.com/fabric8io/osio-pipeline/issues/130
 - https://github.com/fabric8io/osio-pipeline/issues/103